### PR TITLE
Fixup write lock

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -19,3 +19,17 @@
     (com.microsoft.azure.datalake.store.oauth2
       AccessTokenProvider
       ClientCredsTokenProvider)))
+
+
+(defn store [path]
+  (let [store-fqdn (System/getenv "BLOCKS_ADL_TEST_STORE")
+        token-provider (ClientCredsTokenProvider.
+                           (System/getenv "AZ_AUTH_URL")
+                           (System/getenv "AZ_APP_ID")
+                           (System/getenv "AZ_APP_KEY"))
+        client (ADLStoreClient/createClient store-fqdn token-provider)]
+    (->
+      (adl-block-store store-fqdn
+                       :root (or path "/blocks")
+                       :token-provider token-provider)
+      (component/start))))

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -26,8 +26,7 @@
         token-provider (ClientCredsTokenProvider.
                            (System/getenv "AZ_AUTH_URL")
                            (System/getenv "AZ_APP_ID")
-                           (System/getenv "AZ_APP_KEY"))
-        client (ADLStoreClient/createClient store-fqdn token-provider)]
+                           (System/getenv "AZ_APP_KEY"))]
     (->
       (adl-block-store store-fqdn
                        :root (or path "/blocks")


### PR DESCRIPTION
Addressed TODO/FIXMEs in adl block store. The `try-until` "usually" succeeds on the first or second try, so the added latency should be minimal.

I did some functional testing on my own, but could formalize these into basic integration tests:
 * get on a block file with an acl value != "440" is nil, these are not included in listing.
 * put of various block sizes from 1-10, 200-5000 bytes succeed, except for the NPE encountered sporadically noted as a comment in the body of `put!`.