### PR TITLE
Blocks 2.x update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,93 @@
-version: 2
+version: 2.1
 
-jobs:
-  build:
-    working_directory: ~/repo
+# Common executor configuration
+executors:
+  clojure:
     docker:
-      - image: circleci/clojure:lein-2.7.1
+      - image: circleci/clojure:openjdk-11-lein-2.9.1
+    working_directory: ~/repo
+
+
+# Job definitions
+jobs:
+  style:
+    executor: clojure
+    steps:
+      - checkout
+      - run:
+          name: Install cljstyle
+          environment:
+            CLJSTYLE_VERSION: 0.12.1
+          command: |
+            wget https://github.com/greglook/cljstyle/releases/download/${CLJSTYLE_VERSION}/cljstyle_${CLJSTYLE_VERSION}_linux.tar.gz
+            tar -xzf cljstyle_${CLJSTYLE_VERSION}_linux.tar.gz
+      - run:
+          name: Check source formatting
+          command: "./cljstyle check --report"
+
+  lint:
+    executor: clojure
+    steps:
+      - checkout
+      - run:
+          name: Install clj-kondo
+          environment:
+            CLJ_KONDO_VERSION: 2019.12.14
+          command: |
+            wget https://github.com/borkdude/clj-kondo/releases/download/v${CLJ_KONDO_VERSION}/clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
+            unzip clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
+      - run:
+          name: Lint source code
+          command: "./clj-kondo --lint src test blocks-tests/src"
+
+  test:
+    executor: clojure
     steps:
       - checkout
       - restore_cache:
           keys:
-            - blocks-adl-{{ checksum "project.clj" }}
-            - blocks-adl-
+            - v1-test-{{ checksum "project.clj" }}
+            - v1-test-
       - run: lein deps
       - run: lein check
       - run: lein test
-      - run: lein coverage --codecov
+      - save_cache:
+          key: v1-test-{{ checksum "project.clj" }}
+          paths:
+            - ~/.m2
+
+  coverage:
+    executor: clojure
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-coverage-{{ checksum "project.clj" }}
+            - v1-coverage-
+            - v1-test-
+      - run:
+          name: Generate test coverage
+          command: lein coverage --codecov
       - save_cache:
           paths:
             - ~/.m2
-          key: blocks-adl-{{ checksum "project.clj" }}
+          key: v1-coverage-{{ checksum "project.clj" }}
       - store_artifacts:
           path: target/coverage
           destination: coverage
       - run:
           name: Publish Coverage
-          command: "(curl -s https://codecov.io/bash > codecov) && bash codecov -f target/coverage/codecov.json"
+          command: 'bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json'
+
+
+# Workflow definitions
+workflows:
+  version: 2
+  test:
+    jobs:
+      - style
+      - lint
+      - test
+      - coverage:
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             unzip clj-kondo-${CLJ_KONDO_VERSION}-linux-amd64.zip
       - run:
           name: Lint source code
-          command: "./clj-kondo --lint src test blocks-tests/src"
+          command: "./clj-kondo --lint src test"
 
   test:
     executor: clojure

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,11 @@
+{:linters
+ {:consistent-alias
+  {:level :warning
+   :aliases {clojure.java.io io
+             clojure.set set
+             clojure.string str
+             clojure.tools.logging log
+             com.stuartsierra.component component
+             manifold.deferred d
+             manifold.stream s
+             multiformats.hash multihash}}}}

--- a/.cljstyle
+++ b/.cljstyle
@@ -1,0 +1,4 @@
+;; vim: filetype=clojure
+{:padding-lines 2
+ :max-consecutive-blank-lines 3
+ :file-ignore #{".git" "target"}}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /checkouts
 /.lein-*
 /.nrepl-port
+/.clj-kondo/.cache
 pom.xml
 pom.xml.asc
 *.jar

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ This library implements a [content-addressable](https://en.wikipedia.org/wiki/Co
 [block store](https://github.com/greglook/blocks) backed by an Azure Data Lake
 storage account.
 
+
 ## Installation
 
 Library releases are published on Clojars. To use the latest version with
 Leiningen, add the following dependency to your project definition:
 
 [![Clojars Project](http://clojars.org/amperity/blocks-adl/latest-version.svg)](http://clojars.org/amperity/blocks-adl)
+
 
 ## Usage
 
@@ -80,6 +82,7 @@ true
 => (slurp (block/open b2'))
 "1234"
 ```
+
 
 ## License
 

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -21,12 +21,13 @@
       ClientCredsTokenProvider)))
 
 
-(defn store [path]
+(defn store
+  [path]
   (let [store-fqdn (System/getenv "BLOCKS_ADL_TEST_STORE")
         token-provider (ClientCredsTokenProvider.
-                           (System/getenv "AZ_AUTH_URL")
-                           (System/getenv "AZ_APP_ID")
-                           (System/getenv "AZ_APP_KEY"))]
+                         (System/getenv "AZ_AUTH_URL")
+                         (System/getenv "AZ_APP_ID")
+                         (System/getenv "AZ_APP_KEY"))]
     (->
       (adl-block-store store-fqdn
                        :root (or path "/blocks")

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
   :aliases
-  {"coverage" ["with-profile" "+coverage" "cloverage"
-               "--ns-exclude-regex" "blocks.store.tests"]}
+  {"coverage" ["with-profile" "+coverage" "cloverage"]}
 
   :deploy-branches ["master"]
   :pedantic? :abort
@@ -29,19 +28,18 @@
    {:dependencies
     [[org.slf4j/slf4j-simple "1.7.30"]
      [org.slf4j/slf4j-api "1.7.30"]
-     [mvxcvi/test.carly "0.4.1"]]}
+     [mvxcvi/blocks-tests "2.0.3"]]}
 
    :repl
    {:source-paths ["dev"]
     :dependencies [[org.clojure/tools.namespace "1.0.0"]]
-    :jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"]}
+    :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog"
+               "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"]}
 
    :test
-   {:jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"]}
+   {:jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog"]}
 
    :coverage
-   {:plugins [[lein-cloverage "1.0.10"]]
-    :dependencies [[commons-logging "1.2"]
-                   [riddley "0.2.0"]]
+   {:plugins [[lein-cloverage "1.1.1"]]
     :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog"
                "-Dorg.apache.commons.logging.simplelog.defaultlog=trace"]}})

--- a/project.clj
+++ b/project.clj
@@ -12,12 +12,13 @@
   :pedantic? :abort
 
   :dependencies
-  [[org.clojure/clojure "1.9.0"]
-   [org.clojure/tools.logging "0.4.0"]
-   [com.microsoft.azure/azure-data-lake-store-sdk "2.2.8"]
-   [com.stuartsierra/component "0.3.2"]
-   [mvxcvi/blocks "1.1.0"]
-   [mvxcvi/multihash "2.0.3"]]
+  [[org.clojure/clojure "1.10.1"]
+   [org.clojure/tools.logging "1.0.0"]
+   [com.microsoft.azure/azure-data-lake-store-sdk "2.3.8"]
+   [com.stuartsierra/component "1.0.0"]
+   [manifold "0.1.8"]
+   [mvxcvi/blocks "2.0.3"]
+   [mvxcvi/multiformats "0.2.1"]]
 
   :test-selectors
   {:default (complement :integration)
@@ -26,12 +27,13 @@
   :profiles
   {:dev
    {:dependencies
-    [[org.slf4j/slf4j-simple "1.7.21"]
+    [[org.slf4j/slf4j-simple "1.7.30"]
+     [org.slf4j/slf4j-api "1.7.30"]
      [mvxcvi/test.carly "0.4.1"]]}
 
    :repl
    {:source-paths ["dev"]
-    :dependencies [[org.clojure/tools.namespace "0.2.11"]]
+    :dependencies [[org.clojure/tools.namespace "1.0.0"]]
     :jvm-opts ["-Dorg.slf4j.simpleLogger.defaultLogLevel=debug"]}
 
    :test
@@ -40,6 +42,6 @@
    :coverage
    {:plugins [[lein-cloverage "1.0.10"]]
     :dependencies [[commons-logging "1.2"]
-                   [riddley "0.1.15"]]
+                   [riddley "0.2.0"]]
     :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog"
                "-Dorg.apache.commons.logging.simplelog.defaultlog=trace"]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/blocks-adl "0.2.1-SNAPSHOT"
+(defproject amperity/blocks-adl "0.3.0-SNAPSHOT"
   :description "Content-addressable Azure DataLake block store."
   :url "https://github.com/amperity/blocks-adls"
   :license {:name "Apache License 2.0"

--- a/src/blocks/store/adl.clj
+++ b/src/blocks/store/adl.clj
@@ -37,7 +37,7 @@
 
 
 (defn- hex?
-  "True if the valu eis a valid hexadecimal string."
+  "True if the value is a valid hexadecimal string."
   [x]
   (and (string? x) (re-matches #"[0-9a-fA-F]+" x)))
 

--- a/src/blocks/store/adl.clj
+++ b/src/blocks/store/adl.clj
@@ -64,7 +64,7 @@
     (with-meta
       {:id (multihash/parse (.name entry))
        :size (.length entry)
-       :stored-at (.lastModifiedTime entry)}
+       :stored-at (.toInstant (.lastModifiedTime entry))}
       {::store store-fqdn
        ::path (.fullName entry)})))
 

--- a/test/blocks/store/adl_test.clj
+++ b/test/blocks/store/adl_test.clj
@@ -7,10 +7,10 @@
     [com.stuartsierra.component :as component]
     [multiformats.hash :as multihash])
   (:import
-    (com.microsoft.azure.datalake.store.oauth2
-      ClientCredsTokenProvider)
     (com.microsoft.azure.datalake.store
-      ADLStoreClient)))
+      ADLStoreClient)
+    (com.microsoft.azure.datalake.store.oauth2
+      ClientCredsTokenProvider)))
 
 
 ;; ## Integration Tests

--- a/test/blocks/store/adl_test.clj
+++ b/test/blocks/store/adl_test.clj
@@ -4,7 +4,8 @@
     [blocks.store.adl :as adl :refer [adl-block-store]]
     [blocks.store.tests :as tests]
     [clojure.test :refer :all]
-    [multihash.core :as multihash])
+    [com.stuartsierra.component :as component]
+    [multiformats.hash :as multihash])
   (:import
     (com.microsoft.azure.datalake.store.oauth2
       ClientCredsTokenProvider)
@@ -14,27 +15,29 @@
 
 ;; ## Integration Tests
 
-(def az-auth-url (System/getenv "AZ_AUTH_URL"))
-(def az-app-id (System/getenv "AZ_APP_ID"))
-(def az-app-key (System/getenv "AZ_APP_KEY"))
+(def az-token-endpoint (System/getenv "AZ_TOKEN_URL"))
+(def az-client-id (System/getenv "AZ_CLIENT_ID"))
+(def az-client-secret (System/getenv "AZ_CLIENT_SECRET"))
+
 
 (deftest ^:integration check-adl-store
   (if-let [store-fqdn (System/getenv "BLOCKS_ADL_TEST_STORE")]
     (let [token-provider (ClientCredsTokenProvider.
-                           az-auth-url
-                           az-app-id
-                           az-app-key)
+                           az-token-endpoint
+                           az-client-id
+                           az-client-secret)
           client (ADLStoreClient/createClient store-fqdn token-provider)
           root-path (str "/testing/blocks/test-" (rand-int 1000))
           counter (atom 0)]
       (.createDirectory client root-path "770")
-      ; NOTE: can run concurrent tests by making this `check-store*` instead.
+      ;; NOTE: can run concurrent tests by making this `check-store*` instead.
       (tests/check-store
         (fn [& _]
           (let [path (format "%s/%08d" root-path (swap! counter inc))
-                store (adl-block-store store-fqdn
-                                      :root path
-                                      :token-provider token-provider)]
+                store (adl-block-store
+                        store-fqdn
+                        :root path
+                        :token-provider token-provider)]
             (.createDirectory client path "770")
-            store))))
+            (component/start store)))))
     (println "No BLOCKS_ADL_TEST_STORE in environment, skipping integration test!")))

--- a/test/blocks/store/adl_test.clj
+++ b/test/blocks/store/adl_test.clj
@@ -1,11 +1,9 @@
 (ns blocks.store.adl-test
   (:require
-    [blocks.core :as block]
     [blocks.store.adl :as adl :refer [adl-block-store]]
     [blocks.store.tests :as tests]
-    [clojure.test :refer :all]
-    [com.stuartsierra.component :as component]
-    [multiformats.hash :as multihash])
+    [clojure.test :refer [deftest]]
+    [com.stuartsierra.component :as component])
   (:import
     (com.microsoft.azure.datalake.store
       ADLStoreClient)


### PR DESCRIPTION
## Description

This updates the ADL block store to be compatible with the (not really) new [2.X major version](https://github.com/greglook/blocks/blob/master/CHANGELOG.md#200---2019-03-05) of [mvxcvi/blocks](//github.com/greglook/blocks). This is rewritten along the lines of `blocks-s3` with a relatively simple future-wrapping upgrade to asynchrony.

Fixes #3.

## Testing

I ran the generative integration tests with some test credentials and (after fixing a few bugs) they passed!

```
% lein test :integration

lein test blocks.store.adl-test
...
Generative tests passed after 100 trials with seed 1586633542359

Ran 101 tests containing 3747 assertions.
0 failures, 0 errors.
 Elapsed: 7:34.36 User: 37.02s Kernel: 2.763
```